### PR TITLE
s/fail_fast/fail-fast/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ More Java version examples:
 
 Some suggestions that may be helpful when using GitHub Actions.
 
-### Disable `fail_fast` strategy
+### Disable `fail-fast` strategy
 
 By default, GitHub Actions stops running jobs on the first failure. Add the
 following configuration to ensure that all jobs run on every PR even if one job
@@ -77,7 +77,7 @@ fails.
     build:
       runs-on: ubuntu-latest
 +     strategy:
-+       fail_fast: false
++       fail-fast: false
       steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v2


### PR DESCRIPTION
Either this is a typo, or `fail_fast` was renamed to `fail-fast` recently. See [the docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast), or [this job](https://github.com/alexarchambault/json-rpc/commit/f458036676539445d8ad6f878406f798314747e6/checks?check_suite_id=300288944) that failed because of `fail_fast`.