### PR TITLE
Set action as failed when Java can't be installed. Fixes #12

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -54,8 +54,16 @@ function installJava(javaVersion: string, jabbaVersion: string) {
     .grep(javaVersion)
     .head({ "-n": 1 })
     .stdout.trim();
+  if (!toInstall) {
+    core.setFailed(`Couldn't find Java ${javaVersion}`);
+    return;
+  }
   console.log(`Installing ${toInstall}`);
-  shell.exec(`${jabba} install ${toInstall}`);
+  const result = shell.exec(`${jabba} install ${toInstall}`);
+  if (result.code > 0) {
+    core.setFailed(`Failed to install Java ${javaVersion}, Jabba stderr: ${result.stderr}`);
+    return;
+  }
   const javaHome = shell
     .exec(`${jabba} which --home ${toInstall}`)
     .stdout.trim();

--- a/src/install.ts
+++ b/src/install.ts
@@ -55,7 +55,7 @@ function installJava(javaVersion: string, jabbaVersion: string) {
     .head({ "-n": 1 })
     .stdout.trim();
   if (!toInstall) {
-    core.setFailed(`Couldn't find Java ${javaVersion}`);
+    core.setFailed(`Couldn't find Java ${javaVersion}. To fix this problem, run 'jabba ls-remote' to see the list of valid Java versions.`);
     return;
   }
   console.log(`Installing ${toInstall}`);


### PR DESCRIPTION
This marks the action as failed when Java can't be installed. I'm no JS/Github actions expert, but hopefully this would work.