### PR TITLE
Setup Bloop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,7 @@ jobs:
       - uses: ./
       - run: cd test-build && sbt run
         shell: bash
+      - run: ls ~/bin
+        shell: bash
+      - run: cd test-build && sbt bloopInstall && bloop run test-build
+        shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "setup-scala"
-description: "Installs AdoptOpenJDK via Jabba"
+description: "Installs AdoptOpenJDK via Jabba, and Bloop"
 author: "Olafur Pall Geirsson"
 inputs:
   java-version:
@@ -12,6 +12,9 @@ inputs:
   jabba-version:
     description: The Jabba version to install.
     default: "0.11.2"
+  bloop-version:
+    description: The version of Bloop to install.
+    default: "1.4.1"
 runs:
   using: "node12"
   main: "lib/main.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ async function run() {
   try {
     const javaVersion = core.getInput("java-version", { required: true });
     const jabbaVersion = core.getInput("jabba-version", { required: true });
+    const bloopVersion = core.getInput("bloop-version", { required: true });
     console.log(`Installing Java version '${javaVersion}'`);
-    await install(javaVersion, jabbaVersion);
+    await install(javaVersion, jabbaVersion, bloopVersion);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/test-build/project/plugins.sbt
+++ b/test-build/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.1")


### PR DESCRIPTION
In addition to installing sbt, also download the native image of the
Bloop client and install it. This binary will be able to start a Bloop
server if needed.