### PR TITLE
Setup Coursier and sbtn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,11 @@ jobs:
       - run: yarn install
       - run: yarn run build
       - uses: ./
-      - run: cd test-build && sbt run
+      - run: sbt run
+        working-directory: ./test-build
+        shell: bash
+      - run: sbtn run
+        working-directory: ./test-build
         shell: bash
   custom-url:
     runs-on: ubuntu-latest
@@ -24,5 +28,6 @@ jobs:
       - uses: ./
         with:
           java-version: graal@20.2.0=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-amd64-20.2.0.tar.gz
-      - run: cd test-build && sbt run
+      - run: sbt run
+        working-directory: ./test-build
         shell: bash

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,14 +1,23 @@
 import * as core from "@actions/core";
 import * as shell from "shelljs";
 import * as path from "path";
+import * as fs from "fs";
 
 const homedir = require("os").homedir();
 const bin = path.join(homedir, "bin");
+const runnerOs = (shell.env["RUNNER_OS"] || "undefined").toLowerCase();
+const isWindows = runnerOs === "windows";
+
 
 export async function install(javaVersion: string, jabbaVersion: string) {
   setEnvironmentVariableCI();
+  shell.mkdir(bin);
+  core.addPath(bin);
   installJava(javaVersion, jabbaVersion);
   installSbt();
+  const cs = installCoursier();
+  if (!cs) return;
+  installSbtn(cs);
 }
 
 function setEnvironmentVariableCI() {
@@ -16,8 +25,7 @@ function setEnvironmentVariableCI() {
 }
 
 function jabbaUrlSuffix(): string {
-  const runnerOs = shell.env["RUNNER_OS"] || "undefined";
-  switch (runnerOs.toLowerCase()) {
+  switch (runnerOs) {
     case "linux":
       const arch = shell.exec("uname -m", { silent: true }).stdout.trim();
       switch (arch) {
@@ -39,20 +47,16 @@ function jabbaUrlSuffix(): string {
   }
 }
 
-function isWindows(): boolean {
-  return shell.env["RUNNER_OS"] === "Windows";
-}
-
 function jabbaName(): string {
-  if (isWindows()) return "jabba.exe";
+  if (isWindows) return "jabba.exe";
   else return "jabba";
 }
 
 function installJava(javaVersion: string, jabbaVersion: string) {
   core.startGroup("Install Java");
-  core.addPath(bin);
+  
   const jabbaUrl = `https://github.com/shyiko/jabba/releases/download/${jabbaVersion}/jabba-${jabbaVersion}-${jabbaUrlSuffix()}`;
-  shell.mkdir(bin);
+  
   const jabba = path.join(bin, jabbaName());
   shell.set("-ev");
   shell.exec(`curl -sL -o ${jabba} ${jabbaUrl}`, { silent: true });
@@ -112,7 +116,6 @@ function installJavaByExactVersion(javaVersion: string): JabbaInstall {
 
 function installSbt() {
   core.startGroup("Install sbt");
-  core.addPath(bin);
   curl(
     "https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt",
     path.join(bin, "sbt")
@@ -129,4 +132,56 @@ function curl(url: string, outputFile: string) {
   shell.chmod(755, outputFile);
   shell.cat(outputFile);
   console.log(`Downloaded '${path.basename(outputFile)}' to ${outputFile}`);
+}
+
+function installCoursier(): string {
+  core.startGroup("Install coursier");
+  const cs = path.join(bin, coursierName());
+  const csUrl = `https://git.io/coursier-cli-${coursierUrlSuffix()}`
+  shell.exec(`curl -sL -o ${cs} ${csUrl}`, { silent: true });
+  shell.chmod(755, cs);
+  core.endGroup();
+  return cs;
+}
+
+function coursierUrlSuffix(): string {
+  switch (runnerOs) {
+    case "linux":
+      return "linux"
+    case "macos":
+      return "darwin";
+    case "windows":
+      return "windows-exe";
+    default:
+      throw new Error(
+        `unknown runner OS: ${runnerOs}, expected one of linux, macos or windows.`
+      );
+  }
+}
+
+function coursierName(): string {
+  if (isWindows) return "cs.exe";
+  else return "cs";
+}
+
+function installSbtn(cs: string) {
+  core.startGroup("Install sbtn");
+  const result = shell.exec(`${cs} install sbtn --dir ${bin}`);
+  if (result.code > 0) {
+    core.setFailed(
+      `Failed to install sbtn, cs stderr: ${result.stderr}`
+    );
+    return;
+  }
+  if (isWindows) {
+    // create an sbtn bash script on Windows
+    // so that we can call `sbtn` instead of `sbtn.bat`
+    const sbtn = `${bin}/sbtn`
+    const script = `
+    #!/bin/bash 
+    exec sbtn.bat "$@"
+    `
+    fs.writeFileSync(sbtn, script)
+  }
+  core.endGroup();
 }

--- a/test-build/project/build.properties
+++ b/test-build/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.5.3


### PR DESCRIPTION
## Setup Coursier

Coursier can be useful to install any kind of Scala tool inside a Github job.

## Setup sbtn

As a shorter alternative to `sbt --client`, as described in #36.