### PR TITLE
provide official sbt launch script as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@ sbt.
 
 - Configurable Java version: supports OpenJDK, GraalVM, Zulu and any other Java
   version that's installable via Jabba.
-- The `sbt` command is installed using the
-  [paulp/sbt-extras](https://github.com/paulp/sbt-extras/) launcher.
-- For faster startup, the `csbt` command is installed using the Coursier-based
-  [coursier/sbt-extras](https://github.com/coursier/sbt-extras/) launcher. This
-  launcher does not work with all builds, only use `csbt` if you know what you
-  are doing.
 - Cross-platform: works on Linux, macOS, Windows.
+- The `sbt` command is provided, with the official sbt launch script.
+- The following alternate sbt launch scripts are also provided:
+  - `sbtx` runs the [sbt-extras](https://github.com/dwijnand/sbt-extras/) launcher.
+  - `csbt` runs the [Coursier-based sbt-extras](https://github.com/coursier/sbt-extras/) launcher.
 
 ## Usage:
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -114,8 +114,12 @@ function installSbt() {
   core.startGroup("Install sbt");
   core.addPath(bin);
   curl(
-    "https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt",
+    "https://raw.githubusercontent.com/sbt/sbt/develop/sbt",
     path.join(bin, "sbt")
+  );
+  curl(
+    "https://raw.githubusercontent.com/dwijnand/sbt-extras/master/sbt",
+    path.join(bin, "sbtx")
   );
   curl(
     "https://raw.githubusercontent.com/coursier/sbt-extras/master/sbt",


### PR DESCRIPTION
also continue providing sbt-extras, but as `sbtx`

Olaf has already indicated (on Discord, I think it was?) that this change would be welcome