### PR TITLE
Update Node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: The Jabba version to install.
     default: "0.11.2"
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/main.js"
 branding:
   icon: "download"


### PR DESCRIPTION
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: olafurpg/setup-scala@v13. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/